### PR TITLE
integer polynomial division

### DIFF
--- a/numth/types/polynomial.py
+++ b/numth/types/polynomial.py
@@ -257,36 +257,36 @@ class Polynomial:
 
     #-------------------------
 
-#   def mod_gcd(self, other, modulus):
-#       if self == other == Polynomial({0: 0}):
-#           raise ValueError('gcd(0, 0) is undefined')
+    def mod_gcd(self, other, modulus):
+        if self == other == Polynomial({0: 0}):
+            raise ValueError('gcd(0, 0) is undefined')
 
-#       if self.degree == other.degree == 1:
-#           s_m = self.coeffs[0] % modulus
-#           o_m = other.coeffs[0] % modulus
-#           return gcd(s_m, o_m) % modulus
+        if self.degree == other.degree == 1:
+            s_m = self.coeffs[0] % modulus
+            o_m = other.coeffs[0] % modulus
+            return gcd(s_m, o_m) % modulus
 
-#       a, b = self % modulus, other % modulus
-#       while b.degree >= 0:
-#           a, b = b, (a % b) % modulus
+        a, b = self % modulus, other % modulus
+        while b.degree >= 0:
+            a, b = b, (a % b) % modulus
 
-#       return (mod_inverse(a.leading_coeff, modulus) * a) % modulus
+        return (mod_inverse(a.leading_coeff, modulus) * a) % modulus
     
     #-------------------------
     
-#   use subresultant polynomials to compute
-#   def gcd(self, other):
-#       if self == other == polyn('0'):
-#           raise ValueError('gcd(0, 0) is undefined')
-#       
-#       if self.degree == other.degree == 1:
-#           return gcd(self.coeffs[0], other.coeffs[0])
+    use subresultant polynomials to compute
+    def gcd(self, other):
+        if self == other == polyn('0'):
+            raise ValueError('gcd(0, 0) is undefined')
+        
+        if self.degree == other.degree == 1:
+            return gcd(self.coeffs[0], other.coeffs[0])
 
-#       a, b = self.to_integer_polyn(), other.to_integer_polyn()
-#       while b.degree >= 0:
-#           a, b = b, a % b
+        a, b = self.to_integer_polyn(), other.to_integer_polyn()
+        while b.degree >= 0:
+            a, b = b, a % b
 
-#       return a.canonical() / gcd(*a.coeffs.values())
+        return a.canonical() / gcd(*a.coeffs.values())
 
 #===========================================================
 

--- a/tests/test_types_polynomial.py
+++ b/tests/test_types_polynomial.py
@@ -390,16 +390,16 @@ def test_mod_eval(e1, c1, e2, c2, val, mod):
 
 #-----------------------------
 
-#   @given(*coords(4, coeff_min=1))
-#   def test_mod_gcd(e1, c1, e2, c2, e3, c3, e4, c4):
-#       modulus = choice([2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47])
-#       assume( are_distinct(e1, e2) and are_distinct(e3, e4) )
-#       p1 = make(e1, c1, e2, c2) % modulus
-#       p2 = make(e3, c3, e4, c4) % modulus
-#       d = p1.mod_gcd(p2, modulus)
-#       assert( d == p2.mod_gcd(p1, modulus) )
-#       assert( p1 % d % modulus == p2 % d % modulus == polyn('0') )
-#       assert( (p1 // d).mod_gcd(p2 // d, modulus) == polyn('1') )
+    @given(*coords(4, coeff_min=1))
+    def test_mod_gcd(e1, c1, e2, c2, e3, c3, e4, c4):
+        modulus = choice([2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47])
+        assume( are_distinct(e1, e2) and are_distinct(e3, e4) )
+        p1 = make(e1, c1, e2, c2) % modulus
+        p2 = make(e3, c3, e4, c4) % modulus
+        d = p1.mod_gcd(p2, modulus)
+        assert( d == p2.mod_gcd(p1, modulus) )
+        assert( p1 % d % modulus == p2 % d % modulus == polyn('0') )
+        assert( (p1 // d).mod_gcd(p2 // d, modulus) == polyn('1') )
 
 #=============================
 


### PR DESCRIPTION
when performing long division of integer polynomials, if the divisor's leading coefficient does not divide the dividend's coefficients, it leads to rational coefficients.  the denominators of these rational coefficients grow rapidly when performing repeated division, so using this to calculate gcd of integer polynomials is too slow.  this branch is to implement integer polynomial division using subresultants.