### PR TITLE
make Rational class inherit from fractions.Fraction

### DIFF
--- a/numth/basic/division.py
+++ b/numth/basic/division.py
@@ -1,5 +1,7 @@
 #   numth/basic/division.py
 #===========================================================
+import math
+#===========================================================
 
 def div(a, b):
     """
@@ -82,11 +84,7 @@ def gcd(*numbers):
     if numbers == (0, 0):
         raise ValueError('gcd(0, 0) is undefined')
 
-    a, b = numbers
-    while b != 0:
-        a, b = b, a % b
-
-    return abs(a)
+    return math.gcd(*numbers)
 
 #=============================
 

--- a/numth/types/quadratic.py
+++ b/numth/types/quadratic.py
@@ -1,5 +1,7 @@
 #   numth/types/quadratic.py
 #===========================================================
+import math
+
 from ..basic import mod_inverse
 from .rational import frac, Rational
 #===========================================================
@@ -125,7 +127,7 @@ class Quadratic:
         return int(self.to_rational_approx())
 
     def floor(self):
-        return self.component_map(int)
+        return self.component_map(math.floor)
 
     def round(self):
         return self.component_map(_round_prefer_down)
@@ -212,7 +214,7 @@ class Quadratic:
         return return_val
 
     #-------------------------
-    
+
     def __mod__(self, other):
         if type(other) is int:
             return self.component_map(lambda x: x % other)

--- a/numth/types/rational.py
+++ b/numth/types/rational.py
@@ -1,6 +1,8 @@
 #   numth/types/rational.py
 #===========================================================
 from fractions import Fraction
+import math
+import numbers
 import re
 
 from ..config import default
@@ -10,66 +12,103 @@ from ..basic import div, gcd, integer_sqrt, is_square, mod_inverse
 def frac(*inputs):
     """Shortcut to create Rational"""
     if len(inputs) == 1:
-        number = inputs[0]
+        first = inputs[0]
 
-        if type(number) not in Rational.compatible_types():
-            raise ValueError('incompatible type: {}'.format(type(number)))
+        if not isinstance(first, (numbers.Real, str, list, tuple)):
+            raise TypeError('incompatible type for rational number')
 
-        type_name = type(number).__name__
+        type_name = type(first).__name__
         function_name = 'Rational.from_{}'.format(type_name)
-        return eval(function_name)(number)
+        return eval(function_name)(first)
 
     return Rational(*inputs)
 
 #===========================================================
 
-class Rational:
+class Rational(Fraction):
     """
     Rational number class.
 
-    params
-    + numer : int
-    + denom : int
-        nonzero
-
-    represents
-    numer / denom
+    Primarily inherits from fractions.Fraction
     """
-    def __init__(self, numer, denom):
+    def __new__(cls, numer, denom, _normalize=True):
+        self = super(Rational, cls).__new__(cls)
+
         if denom == 0:
-            raise ValueError('Attempted division by zero')
+            raise ZeroDivisionError('Rational(_, 0)')
 
-        if numer * denom < 0:
-            sgn = -1
-        else:
-            sgn = 1
+        if _normalize:
+            d = math.gcd(numer, denom)
+            if denom < 0:
+                d = -d
+            numer = numer // d
+            denom = denom // d
 
-        d = gcd(numer, denom)
-        self.numer = sgn * abs(numer) // d
-        self.denom = abs(denom) // d
-        self.sign = sgn
+        self._numerator = numer
+        self._denominator = denom
+        return self
+
+    #-------------------------
+
+    @property
+    def numer(self):
+        return self._numerator
+
+    @property
+    def denom(self):
+        return self._denominator
+
+    @classmethod
+    def from_int(self, integer):
+        return Rational(integer, 1, _normalize=False)
+
+    @classmethod
+    def from_Rational(self, rational):
+        return rational
+
+    @classmethod
+    def from_Fraction(self, fraction):
+        return Rational(
+            fraction._numerator,
+            fraction._denominator,
+            _normalize=False
+        )
+
+    @classmethod
+    def from_float(self, fl):
+        return Rational.from_str(str(fl))
+
+    @classmethod
+    def from_str(self, string):
+        return Rational.from_Fraction(Fraction(string.replace(' ', '')))
+
+    @classmethod
+    def from_list(self, li):
+        return Rational(*li)
+
+    @classmethod
+    def from_tuple(self, tu):
+        return Rational(*tu)
 
     #-------------------------
 
     def __repr__(self):
-        if self.denom == 1:
-            return '{}'.format(self.numer)
-        return '{}/{}'.format(self.numer, self.denom)
+        if self._denominator == 1:
+            return '{}'.format(self._numerator)
+        return '{}/{}'.format(self._numerator, self._denominator)
 
     #-------------------------
 
     def display(self):
         """Pretty-print rational number."""
         minus = self.sign == -1
-        numer = abs(self.numer)
-        denom = self.denom
-        numer_length = len(str(numer))
-        denom_length = len(str(denom))
-        length = max(numer_length, denom_length)
-        numer_offset = (length - numer_length + 1) // 2
-        denom_offset = (length - denom_length + 1) // 2
-        numer = ' '*(minus + numer_offset + 1) + str(numer)
-        denom = ' '*(minus + denom_offset + 1) + str(denom)
+        numer = str(abs(self._numerator))
+        denom = str(self._denominator)
+        length = max(len(numer), len(denom))
+        numer_offset = (length - len(numer) + 1) // 2
+        denom_offset = (length - len(denom) + 1) // 2
+        numer = ' '*(minus + numer_offset + 1) + numer
+        denom = ' '*(minus + denom_offset + 1) + denom
         line = '-'*minus + ' ' + '\u2500'*length
         return '{}\n{}\n{}'.format(numer, line, denom)
 
@@ -87,133 +126,37 @@ class Rational:
             decimal representation of self
         """
         if num_digits == 0:
-            return str(round(self))
+            return str(self.round_to_nearest_int())
+
+        sign = '-' if self._numerator < 0 else ''
 
         num_digits = num_digits or default('decimal_digits')
 
-        quotient, remainder = div(self.numer, self.denom)
+        quotient, remainder = divmod(abs(self._numerator), self._denominator)
         if num_digits == 0:
-            return format(quotient)
-        digits = format(round(Rational(remainder*10**num_digits, self.denom)))
+            return str(quotient)
+        shifted_rem = Rational(remainder * 10**num_digits, self._denominator)
+        digits = str(shifted_rem.round_to_nearest_int())
         num_zeros = num_digits - len(digits)
 
-        return '{}.{}{}'.format(quotient, '0'*num_zeros, digits)
+        return '{}{}.{}{}'.format(sign, quotient, '0'*num_zeros, digits)
 
     #=========================
-
-    def compare(self, other):
-        other_ = frac(other)
-        return self.numer * other_.denom - self.denom * other_.numer
-
-    def __eq__(self, other):
-        if type(other) in [int, float, Fraction, Rational]:
-            return self.compare(other) == 0
-        return other == self
-
-    def __ne__(self, other):
-        return not (self == other)
-
-    def __lt__(self, other):
-        if type(other) in [int, float, Fraction, Rational]:
-            return self.compare(other) < 0
-        return other > self
-
-    def __gt__(self, other):
-        if type(other) in [int, float, Fraction, Rational]:
-            return self.compare(other) > 0
-        return other < self
-
-    def __le__(self, other):
-        return not (self > other)
-
-    def __ge__(self, other):
-        return not (self < other)
-
-    #=========================
-
-    def __int__(self):
-        return self.numer // self.denom
-
-    def __float__(self):
-        return self.numer / self.denom
-
-    def __round__(self):
-        return int(Rational(2*self.numer + self.denom, 2*self.denom))
-
-    def __neg__(self):
-        return Rational(-self.numer, self.denom)
-
-    def __abs__(self):
-        return Rational(abs(self.numer), self.denom)
 
     def inverse(self):
-        return Rational(self.denom, self.numer)
-
-    #=========================
-
-    def __add__(self, other):
-        if type(other) in [int, float, Rational]:
-            other_ = frac(other)
-            d = gcd(self.denom, other_.denom)
-            self_scalar = other_.denom // d
-            other_scalar = self.denom // d
-            numer = (self.numer * self_scalar) + (other_.numer * other_scalar)
-            denom = self_scalar * self.denom
-            return Rational(numer, denom)
-        return other + self
-
-    def __radd__(self, other):
-        return self + other
+        if self._numerator < 0:
+            return Rational(-self._denominator, -self._numerator, _normalize=False)
+        return Rational(self._denominator, self._numerator, _normalize=False)
 
     #-------------------------
 
-    def __sub__(self, other):
-        return self + (-other)
-
-    def __rsub__(self, other):
-        return -self + other
+    def round_to_nearest_int(self):
+        return math.floor(self + Rational(1, 2))
 
     #-------------------------
 
-    def __mul__(self, other):
-        if type(other) in [int, float, Rational]:
-            return Rational(self.numer*frac(other).numer, self.denom*frac(other).denom)
-        return other * self
-
-    def __rmul__(self, other):
-        return self * other
-
-    #-------------------------
-
-    def __truediv__(self, other):
-        if type(other) in [int, float, Rational]:
-            return self * frac(other).inverse()
-        return self * other.inverse()
-
-    def __rtruediv__(self, other):
-        return self.inverse() * other
-
-    #-------------------------
-
-    def __pow__(self, other):
-        if type(other) is not int:
-            raise ValueError('Exponent must be an integer')
-
-        if other == 0:
-            return Rational(1, 1)
-        elif other < 0:
-            return (self**(-other)).inverse()
-        else:
-            return Rational(pow(self.numer, other), pow(self.denom, other))
-
-    #-------------------------
-
-    def __mod__(self, other):
-        if type(other) is not int or other < 2:
-            raise ValueError('Modulus must an integer greater than 1')
-
-        inv_denom = mod_inverse(self.denom, other)
-        return (self.numer * inv_denom) % other
+    def is_square(self):
+        return is_square(self._numerator) and is_square(self._denominator)
 
     #=========================
 
@@ -237,9 +180,9 @@ class Rational:
         num_digits = num_digits or default('decimal_digits')
 
         other_ = frac(other)
-        ad = self.numer * other_.denom
-        bc = self.denom * other_.numer
-        bd = self.denom * other_.denom
+        ad = self._numerator * other_._denominator
+        bc = self._denominator * other_._numerator
+        bd = self._denominator * other_._denominator
 
         return 10**num_digits * abs(ad - bc) < abs(bd)
 
@@ -261,17 +204,17 @@ class Rational:
         if self < 0:
             raise ValueError('Cannot take square root of negative number')
 
-        numer_integer_sqrt = integer_sqrt(self.numer)
-        denom_integer_sqrt = integer_sqrt(self.denom)
+        numer_integer_sqrt = integer_sqrt(self._numerator)
+        denom_integer_sqrt = integer_sqrt(self._denominator)
         guess = Rational(numer_integer_sqrt, denom_integer_sqrt)
 
-        if numer_integer_sqrt**2 == self.numer \
-                and denom_integer_sqrt**2 == self.denom:
+        if numer_integer_sqrt**2 == self._numerator \
+                and denom_integer_sqrt**2 == self._denominator:
             return guess
 
         num_digits = num_digits or default('sqrt_digits')
 
-        if self.numer > self.denom:
+        if self._numerator > self._denominator:
             other_guess = self / guess
 
             while not guess.approx_equal(other_guess, num_digits):
@@ -298,7 +241,7 @@ class Rational:
         return
         Rational
         """
-        if self.numer <= self.denom:
+        if self._numerator <= self._denominator:
             raise ValueError('Inverse square root only if greater than 1')
 
         guess = self.sqrt(2).inverse()
@@ -310,82 +253,97 @@ class Rational:
 
         return guess
 
-    #-------------------------
+    #=========================
 
-    def is_square(self):
-        return is_square(self.numer) and is_square(self.denom)
+    def __pos__(self):
+        return self
+
+    def __neg__(self):
+        return Rational(
+            -self._numerator,
+            self._denominator,
+            _normalize=False
+        )
+
+    def __abs__(self):
+        return Rational(
+            abs(self._numerator),
+            self._denominator,
+            _normalize=False
+        )
 
     #=========================
 
-    def compatible_types():
-        return [int, float, str, list, tuple, Fraction, Rational]
+    def __add__(self, other):
+        if type(other) is int:
+            return Rational(
+                self._numerator + other * self._denominator,
+                self._denominator
+            )
+        if isinstance(other, numbers.Rational):
+            return Rational(
+                self._numerator * other._denominator + self._denominator * other._numerator,
+                self._denominator * other._denominator
+            )
+        return NotImplemented
+
+    def __sub__(self, other):
+        return self + (-other)
+
+    def __mul__(self, other):
+        if type(other) is int:
+            return Rational(
+                self._numerator * other,
+                self._denominator
+            )
+        if isinstance(other, numbers.Rational):
+            return Rational(
+                self._numerator * other._numerator,
+                self._denominator * other._denominator
+            )
+        return NotImplemented
+
+    def __truediv__(self, other):
+        if type(other) is int:
+            return Rational(
+                self._numerator,
+                self._denominator * other
+            )
+        if isinstance(other, numbers.Rational):
+            return Rational(
+                self._numerator * other._denominator,
+                self._denominator * other._numerator
+            )
+        return NotImplemented
+
+    def __pow__(self, other):
+        if isinstance(other, numbers.Rational) and other.denominator == 1:
+            if other == 0:
+                return Rational(1, 1)
+            elif other < 0:
+                return (self**(-other)).inverse()
+            return Rational(
+                self._numerator ** other,
+                self._denominator ** other,
+                _normalize=False
+            )
+        return NotImplemented
 
     #-------------------------
 
-    def from_int(int_):
-        return Rational(int_, 1)
+    def __radd__(self, other):
+        return self + other
 
-    #-------------------------
+    def __rsub__(self, other):
+        return -self + other
 
-    def from_float(float_):
-        exponent_pattern = re.fullmatch(r'(.+)e([\+\-]?\d+)', str(float_))
-        if exponent_pattern is None:
-            number, exponent = str(float_), None
-        else:
-            number, exponent = exponent_pattern.group(1, 2)
+    def __rmul__(self, other):
+        return self * other
 
-        decimal_pattern = re.fullmatch(r'([\+\-]?\d+)\.(\d+)', str(number))
-        if decimal_pattern is None:
-            numer, denom = int(number), 1
-        else:
-            whole, decimal = decimal_pattern.group(1, 2)
-            numer = int(whole + decimal)
-            denom = 10**len(decimal)
+    def __rtruediv__(self, other):
+        return self.inverse() * other
 
-        if exponent is None:
-            return Rational(numer, denom)
-
-        exp = int(exponent)
-        if exp < 0:
-            return Rational(numer, denom * 10**(-exp))
-        return Rational(numer * 10**exp, denom)
-
-    #-------------------------
-
-    def from_str(string_):
-        try:
-            int_ = int(string_)
-            return Rational.from_int(int_)
-        except:
-            pass
-
-        try:
-            float_ = float(string_)
-            return Rational.from_float(float_)
-        except:
-            pass
-
-        pattern = re.match(r'([\+\-]?\d+)\/(\d+)', ''.join(string_.split()))
-        if pattern is not None:
-            return Rational(*map(int, pattern.group(1, 2)))
-
-    #-------------------------
-
-    def from_list(list_):
-        return Rational(*list_)
-
-    #-------------------------
-
-    def from_tuple(tuple_):
-        return Rational(*tuple_)
-
-    #-------------------------
-
-    def from_Fraction(Fraction_):
-        return Rational(Fraction_.numerator, Fraction_.denominator)
-
-    #-------------------------
-
-    def from_Rational(Rational_):
-        return Rational_
-
+    def __rpow__(self, other):
+        if self.denom == 1:
+            return other ** self.numer
+        return NotImplemented

--- a/numth/types/rational.py
+++ b/numth/types/rational.py
@@ -3,7 +3,6 @@
 from fractions import Fraction
 import math
 import numbers
-import re
 
 from ..config import default
 from ..basic import div, gcd, integer_sqrt, is_square, mod_inverse

--- a/tests/types_quadratic_test.py
+++ b/tests/types_quadratic_test.py
@@ -1,8 +1,8 @@
 #   tests/types_quadratic_test.py
 #===========================================================
 import env
-from hypothesis import given, assume, strategies as st
 import math
+from hypothesis import given, assume, strategies as st
 
 from numth.basic import gcd, is_square
 from numth.types import Rational
@@ -90,11 +90,17 @@ def test_neg(real, imag, root):
 @given(*coords(rmin=2))
 def test_int(real, imag, root):
     n = int(Quadratic(real, imag, root))
-    if imag >= 0:
-        assert( (n - real)**2 <= imag**2 * root < (n - real + 1)**2 )
+    if n >= 0:
+        if imag >= 0:
+            assert( (n - real)**2 <= imag**2 * root < (n - real + 1)**2 )
+        else:
+            assert( (n - real)**2 >= imag**2 * root > (n - real + 1)**2 )
     else:
-        assert( (n - real)**2 >= imag**2 * root > (n - real + 1)**2 )
-    
+        if imag <= 0:
+            assert( (-n + real)**2 <= imag**2 * root < (-n + real + 1)**2 )
+        else:
+            assert( (-n + real)**2 >= imag**2 * root > (-n + real + 1)**2 )
+
 #-----------------------------
 
 @given(*rational_coords())
@@ -114,7 +120,7 @@ def test_round(real_numer, real_denom, imag_numer, imag_denom, root):
     a = Quadratic(real, imag, root).round()
     assert( a.real == _round_prefer_down(real) )
     assert( a.imag == _round_prefer_down(imag) )
-    
+
 #-----------------------------
 
 @given(*coords(rmin=2))
@@ -253,7 +259,7 @@ def test_floordiv_quadratic_and_integer(real, imag, root, integer):
 #=============================
 
 @given(
-    *coords(), 
+    *coords(),
     st.integers(min_value=-20, max_value=20),
     st.integers(min_value=-10, max_value=10)
 )


### PR DESCRIPTION
1. it would be good to have the `Rational` class fit in the hierarchy of numbers defined in python
2. `fractions.Fraction` is faster
3. i want some extra methods in the `Rational` subclass, which is why we need to redefine the operators so that they always return the `Rational` subclass
4. i want some stringent requirements for how a `Rational` can be instantiated.  so the`__new__` method is rewritten to only allow integer inputs.  the instantiation from other types is handled by the `frac` helper method as before, although some of the methods can just use the `fractions.Fraction` versions since those already do most of what i was trying to do.